### PR TITLE
Carlos agrelis patch 2

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -9,7 +9,8 @@
             'internal_type' => 'db',
             'allowed' => 'pages',
             'maxitems' => 1,
-            'size' => 1
+            'size' => 1,
+            'default' => 0
         ]
     ],
     'tx_abtest2_cookie_time' => [


### PR DESCRIPTION
Removing A/B testing from a page is not possible without setting default value of B page ID. Without it, changes on page can not be saved, SQL error.