### PR TITLE
Restore realurl compatibility

### DIFF
--- a/Classes/Helper.php
+++ b/Classes/Helper.php
@@ -45,9 +45,13 @@ class Helper
 
         $currentPageId = $targetPageId = $tsFeController->id;
 
-        // Get the rootpage_id
-        $pageRepository = GeneralUtility::makeInstance(PageRepository::class);
-        $rootpage_id = array_pop($pageRepository->getRootLine($GLOBALS['TSFE']->id));
+        // Get the rootpage_id from realurl config.
+        $realurlConfig = $tsFeController->TYPO3_CONF_VARS['EXTCONF']['realurl'];
+        if (is_array($realurlConfig) && array_key_exists($_SERVER['SERVER_NAME'], $realurlConfig)) {
+            $rootpage_id = $realurlConfig[$_SERVER['SERVER_NAME']]['pagePath']['rootpage_id'];
+        } else {
+            $rootpage_id = $realurlConfig['_DEFAULT']['pagePath']['rootpage_id'];
+        }
 
         // If the ID is NULL, then we set this value to the rootpage_id. NULL is the "Home"page, ID is a specific sub-page, e.g. www.domain.de (NULL) - www.domain.de/page.html (ID)
         if (!$currentPageId) {
@@ -59,6 +63,7 @@ class Helper
             }
         }
 
+        $pageRepository = GeneralUtility::makeInstance(PageRepository::class);
         $currentPagePropertiesArray = $pageRepository->getPage($currentPageId);
 
         $pageBPageId = $currentPagePropertiesArray['tx_abtest2_b_id'];


### PR DESCRIPTION
https://github.com/svewap/abtest2/pull/1 removed support for TYPO3 7, 8 and 9 instances with realurl enabled.
Instead of dropping support completely, it would be better to evaluate the realurl configuration if realurl is installed and loaded.
This pull request restores compatibility for TYPO3 7, 8 and 9 instances with realurl enabled while keeping compatibility for instances without realurl.